### PR TITLE
Fix launch error with catkin_make option

### DIFF
--- a/base/ros_entrypoint.sh
+++ b/base/ros_entrypoint.sh
@@ -28,10 +28,10 @@ if [[ $(id -u) -eq 0 ]]; then
 
 	# setup ros environment
 	if [[ "$BUILD_TOOL" == "catkin_make" ]]; then
-		touch /home${DEFAULT_USER}/.bash_aliases
+		touch /home/${DEFAULT_USER}/.bash_aliases
 		echo "function catkin_make(){(cd ~/catkin_ws && command catkin_make \$@) && source ~/catkin_ws/devel/setup.bash;}" >> /home/${DEFAULT_USER}/.bash_aliases
 		mkdir -p /home/${DEFAULT_USER}/catkin_ws/src \
-		&& /bin/bash -c ". /opt/ros/melodic/setup.bash; catkin_init_workspace /home/${DEFAULT_USER}/catkin_ws/src"
+		&& /bin/bash -c ". /opt/ros/melodic/setup.bash; catkin_init_workspace /home/${DEFAULT_USER}/catkin_ws/src" > /dev/null
 		echo 'source /opt/ros/melodic/setup.bash' >> /home/${DEFAULT_USER}/.bashrc
 	fi
 	if [[ "$BUILD_TOOL" == "catkin-tools" ]]; then


### PR DESCRIPTION
以下のエラーが出るので修正します

```
$ docker run --rm -it -e BUILD_TOOL="catkin_make" tiryoh/ros-melodic-desktop
touch: cannot touch '/homeubuntu/.bash_aliases': No such file or directory
```