### PR TITLE
refactor: Update argument parser in entrypoint

### DIFF
--- a/base/ros_entrypoint.sh
+++ b/base/ros_entrypoint.sh
@@ -59,8 +59,8 @@ fi
 
 echo "Launched container with user: $DEFAULT_USER, uid: $DEFAULT_USER_UID, gid: $DEFAULT_USER_GID"
 
-if [ $# -gt 1 ]; then
-	echo $@ | $EXEC /bin/bash -li
+if which "$1" > /dev/null 2>&1 ; then
+	$EXEC "$@"
 else
-	$EXEC bash -li -c "$@"
+	echo $@ | $EXEC $SHELL -li
 fi


### PR DESCRIPTION
Update argument parser in `ros_entrypoint.sh`

## current pattern

```sh
if [ $# -gt 1 ]; then
	echo $@ | $EXEC /bin/bash -li
else
	$EXEC bash -li -c "$@"
fi
```

```
$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop whoami
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop ls /ws
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu@9a6d038f030b:/$ ls /ws
Dockerfile  ros_entrypoint.sh
ubuntu@9a6d038f030b:/$ logout

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop "cd /home/ubuntu; ls"
Launched container with user: ubuntu, uid: 1000, gid: 1000
cd /home/ubuntu; ls
catkin_ws
```

## proposal pattern

```sh
if which "$1" > /dev/null 2>&1 ; then
	$EXEC "$@"
else
	echo $@ | $EXEC $SHELL -li
fi
```

```
$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop whoami
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop ls /home
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop "cd /home/ubuntu; ls"
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu@43d733f638ae:/$ cd /home/ubuntu; ls
catkin_ws
ubuntu@43d733f638ae:~$ logout
```

## pattern A

```sh
echo $@ | $EXEC /bin/bash -li
```

```
$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop whoami
Launched container with user: ubuntu, uid: 1000, gid: 1000
whoami
ubuntu@4bdb0fb70842:/$ whoami
ubuntu
ubuntu@4bdb0fb70842:/$ logout

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop ls /ws
Launched container with user: ubuntu, uid: 1000, gid: 1000
ls /ws
ubuntu@a6e567e014c8:/$ ls /ws
Dockerfile  ros_entrypoint.sh
ubuntu@a6e567e014c8:/$ logout

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop "cd /home/ubuntu; ls"
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu@fd40a62de4d6:/$ cd /home/ubuntu; ls
catkin_ws
ubuntu@fd40a62de4d6:~$ logout
```

## pattern B

```sh
$EXEC bash -li -c "$@"
```

```
$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop whoami
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop ls /ws
Launched container with user: ubuntu, uid: 1000, gid: 1000
 bin   boot   dev   echo   etc   home   lib   lib32   lib64   libx32   media   mnt   opt   proc   root   ros_entrypoint.sh   run   sbin  'source '   srv   sys   tmp   usr   var   ws

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop "cd /home/ubuntu; ls"
Launched container with user: ubuntu, uid: 1000, gid: 1000
catkin_ws

```


## pattern C

```sh
$EXEC "$@"
```

```
$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop whoami
Launched container with user: ubuntu, uid: 1000, gid: 1000
ubuntu

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop ls /ws
Launched container with user: ubuntu, uid: 1000, gid: 1000
ls /ws
Dockerfile  ros_entrypoint.sh

$ docker run --rm -it -v ${PWD}:/ws tiryoh/ros-melodic-desktop "cd /home/ubuntu; ls"
Launched container with user: ubuntu, uid: 1000, gid: 1000
cd /home/ubuntu; ls
su-exec: cd /home/ubuntu; ls: No such file or directory
```


